### PR TITLE
Use ref instead of id in order to work with nuxt

### DIFF
--- a/src/UploadButton.vue
+++ b/src/UploadButton.vue
@@ -3,6 +3,7 @@
     class="upload-btn"
   >
     <input
+      :id="`${_uid}uploadFile`"
       ref="uploadFile"
       type="file"
       :name="name"

--- a/src/UploadButton.vue
+++ b/src/UploadButton.vue
@@ -3,7 +3,7 @@
     class="upload-btn"
   >
     <input
-      :id="`${_uid}uploadFile`"
+      ref="uploadFile"
       type="file"
       :name="name"
       :accept="accept"
@@ -172,7 +172,7 @@ export default {
       }
     },
     clear() {
-      document.getElementById(`${this._uid}uploadFile`).value = ''
+      this.$refs.uploadFile.value = ''
       this.$emit('file-update')
       this.uTitle = null
     }


### PR DESCRIPTION
When server-side rendering this component, you get the error: "document is not defined".

By using the refs instead of a document selector, we should be on the safe side.